### PR TITLE
default configuration setting added

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -44,7 +44,7 @@
         $scope.nextNotification = nextNotification;
         $scope.setConnectorType = setConnectorType;
         $scope.setConnectorConfiguration = setConnectorConfiguration;
-        $scope.checkFAZConnectoHealth = checkFAZConnectoHealth;
+        $scope.checkFAZConnectorHealth = checkFAZConnectorHealth;
         $scope.isLightTheme = $rootScope.theme.id === 'light';
         $scope.widgetBasePath = widgetBasePath;
         $scope.startInfoGraphics = $scope.isLightTheme ? widgetBasePath + 'images/start-light.svg' : widgetBasePath + 'images/start-dark.svg';
@@ -191,17 +191,21 @@
         function setConnectorConfiguration(){
             if($scope.config.selectedConfig){
                 $scope.selectedEnv.fazConnectorConfig = $scope.config.selectedConfig;
-                checkFAZConnectoHealth();
+                checkFAZConnectorHealth();
             }
         }
 
-        function checkFAZConnectoHealth() {
+        function checkFAZConnectorHealth() {
             $scope.healthCheckProcessing = true;
             let connectorMetaData = {
                 'name': fazConnector.name,
                 'version': fazConnector.version
             }
-            connectorService.getConnectorHealth(connectorMetaData, $scope.config.selectedConfig.config_id).then(function (connectorHealth) {
+            let agentId;
+            if ($scope.config.connectorType === 'Agent'){
+                agentId = $scope.config.selectedConfig.agent;
+            }
+            connectorService.getConnectorHealth(connectorMetaData, $scope.config.selectedConfig.config_id, agentId).then(function (connectorHealth) {
                 $scope.config.fazConnectorHealth = connectorHealth;
             }, function (error) {
                 console.log(error);

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -42,6 +42,9 @@
         $scope.toggleParametersSettings = { open: false };
         $scope.backNotification = backNotification;
         $scope.nextNotification = nextNotification;
+        $scope.setConnectorType = setConnectorType;
+        $scope.setConnectorConfiguration = setConnectorConfiguration;
+        $scope.checkFAZConnectoHealth = checkFAZConnectoHealth;
         $scope.isLightTheme = $rootScope.theme.id === 'light';
         $scope.widgetBasePath = widgetBasePath;
         $scope.startInfoGraphics = $scope.isLightTheme ? widgetBasePath + 'images/start-light.svg' : widgetBasePath + 'images/start-dark.svg';
@@ -54,6 +57,9 @@
         $scope.params = { activeTab: 0 };
         $scope.noDefaultConnectorSelected = false;
         $scope.config = config;
+        $scope.connectorTypeList = ['Self', 'Agent'];
+        $scope.config.connectorType = 'Self';
+        $scope.allConfigurations = [];
         const nistConnectorName = 'NIST National Vulnerability Database';
         $scope.ingestionDetails = {
             "name": "Outbreak-Alerts",
@@ -87,6 +93,7 @@
 
         $scope.parent_wf_id = '';
         var subscription;
+        var fazConnector;
 
         $scope.$on('websocket:reconnect', function () {
             initWebsocket();
@@ -154,6 +161,56 @@
             }
         }
 
+        //update connector Configuration list as per connector type
+        function setConnectorType() {
+            $scope.allConfigurations = [];
+            const _connectorName = fazConnector.name;
+            const _connectorVersion = fazConnector.version;
+            if ($scope.config.connectorType === 'Self') {
+                connectorService.getConnector(_connectorName, _connectorVersion).then(function (connectorDetails) {
+                    $scope.allConfigurations.push(...connectorDetails.configuration);
+                });
+            }
+            else {
+                let connectorInfo = {
+                    name: _connectorName,
+                    version: _connectorVersion
+                }
+                connectorService.getAgents(connectorInfo).then(function (agentDetails) { //check and fetch agent
+                    if (agentDetails && agentDetails.length > 0) {
+                        agentDetails.forEach(agentElement => {
+                            connectorService.getConnector(_connectorName, _connectorVersion, agentElement.agent).then(function (connectorDetails) { //check and fetch agent
+                                $scope.allConfigurations.push(...connectorDetails.configuration);
+                            });
+                        });
+                    }
+                });
+            }
+        }
+
+        function setConnectorConfiguration(){
+            if($scope.config.selectedConfig){
+                $scope.selectedEnv.fazConnectorConfig = $scope.selectedEnv.fazConnectorConfig;
+                checkFAZConnectoHealth();
+            }
+        }
+
+        function checkFAZConnectoHealth() {
+            $scope.healthCheckProcessing = true;
+            let connectorMetaData = {
+                'name': fazConnector.name,
+                'version': fazConnector.version
+            }
+            connectorService.getConnectorHealth(connectorMetaData, $scope.config.selectedConfig.config_id).then(function (connectorHealth) {
+                $scope.config.fazConnectorHealth = connectorHealth;
+            }, function (error) {
+                console.log(error);
+                return;
+            }).finally(function () {
+                $scope.healthCheckProcessing = false;
+            })
+        }
+
         function _activeErrorTab(tabName, tabIndex) {
             $scope.params.activeTab = CommonUtils.isUndefined(tabIndex) ? 0 : tabIndex;
             if (CommonUtils.getObjectLength($scope.huntparams) === 0) {
@@ -180,6 +237,7 @@
         async function configHuntTool() {
             $scope.isConnectorsInstalled = true;
             $scope.selectedConnectorName = nistConnectorName;
+            $scope.toggleSelectConfiguration = { open: false };
             const queryBody = {
                 logic: "AND",
                 filters: [{
@@ -211,6 +269,10 @@
                         }
                         $scope.isConnectorsInstalled = false;
                         WizardHandler.wizard('OutbreaksolutionpackWizard').next();
+                    }
+                    fazConnector = _.find($scope.installedConnectors,{label  : 'Fortinet FortiAnalyzer'});
+                    if(fazConnector){
+                        setConnectorType();
                     }
                 } else {
                     toaster.error({ body: 'Threat Hunt Tool parameters is not found in Key-Store' });
@@ -386,6 +448,15 @@
         }
 
         function nextNotification(threatHuntConfigForm) {
+            if(threatHuntConfigForm.selectConfigForm && (threatHuntConfigForm.selectConfigForm.$invalid || threatHuntConfigForm.selectConfigForm.$pristine)){
+                toaster.error({
+                    body: 'Select atleast one configuration for Fortinet FortiAnalyzer'
+                });
+                var huntToolIndex = $scope.selectedEnv.huntTools.indexOf('Fortinet FortiAnalyzer');
+                _activeErrorTab('Fortinet FortiAnalyzer', huntToolIndex);
+                loadActiveTab(huntToolIndex);
+                $scope.toggleSelectConfiguration.open = true;
+            }
             if (!CommonUtils.isUndefined(threatHuntConfigForm.fazForm) && threatHuntConfigForm.fazForm.$invalid) {
                 _connectorErrorHandling('Fortinet FortiAnalyzer');
                 return;
@@ -438,7 +509,6 @@
                     });
                     return;
                 }
-                $scope.selectedEnv.fazConnectorConfig = _.find($scope.installedConnectors, { label: 'Fortinet FortiAnalyzer' });
                 if (CommonUtils.isUndefined($scope.selectedEnv.autoInstallOutbreaks)) {
                     $scope.selectedEnv.autoInstallOutbreaks = {
                         installSelectedOutbreaks: true,
@@ -447,6 +517,13 @@
                     };
                 } else {
                     $scope.selectedEnv.autoInstallOutbreaks.installOutbreakType = $scope.outbreakAlertSeverityList.slice();
+                }
+                if($scope.config.fazConnectorHealth && $scope.config.fazConnectorHealth.status !== 'Available'){
+                    toaster.error({
+                        body: `Check health of default configuration.`
+                    });
+                    $scope.toggleSelectConfiguration.open = true;
+                    return;
                 }
                 WizardHandler.wizard('OutbreaksolutionpackWizard').next();
             } else {

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -190,7 +190,7 @@
 
         function setConnectorConfiguration(){
             if($scope.config.selectedConfig){
-                $scope.selectedEnv.fazConnectorConfig = $scope.selectedEnv.fazConnectorConfig;
+                $scope.selectedEnv.fazConnectorConfig = $scope.config.selectedConfig;
                 checkFAZConnectoHealth();
             }
         }

--- a/widget/view.html
+++ b/widget/view.html
@@ -151,7 +151,7 @@
                                             data-ng-class="toggleSelectConfiguration.open ? 'fa-chevron-down' : 'fa-chevron-right'"></i></span>
                                       </div>
                                       <div class="pull-left queue-card-header-text margin-right-3">
-                                          Select default configuration for outbreak investigation
+                                          Select default configuration for Outbreak Investigation
                                       </div>
                                     </div>
                                   </div>
@@ -160,7 +160,7 @@
                                   <div id="selectConfig"
                                     class="margin-top-negative-20 margin-top-md padding-left-0 padding-right-0 threat-hunt-connector-config-width">
                                     <div>
-                                      <div><label class="font-075em">Select Configuration Target</label><span class="required text-danger">*</span></div>
+                                      <div><label class="font-075em">Select Target</label><span class="required text-danger">*</span></div>
                                       <div
                                         data-ng-class="{ 'has-error':threatHuntConfigForm.selectConfigForm.$invalid || threatHuntConfigForm.selectConfigForm.$pristine}"
                                         class="cs-select width-275">

--- a/widget/view.html
+++ b/widget/view.html
@@ -141,6 +141,81 @@
                                   </div>
                                 </div>
                               </div>
+
+                              <div uib-accordion-group class="panel-default" data-ng-if="huntTool.label==='Fortinet FortiAnalyzer'"
+                                id="accordion-connector-display-{{ $index }}" is-open="toggleSelectConfiguration.open" style="width: 100%;">
+                                <uib-accordion-heading class="padding-md">
+                                  <div class="clearfix">
+                                    <div data-ng-class="{'queue-text-active-color': toggleSelectConfiguration.open}">
+                                      <div class="margin-right-lg pull-left"><span class="queue-card-actions">&nbsp;<i class="fa"
+                                            data-ng-class="toggleSelectConfiguration.open ? 'fa-chevron-down' : 'fa-chevron-right'"></i></span>
+                                      </div>
+                                      <div class="pull-left queue-card-header-text margin-right-3">
+                                          Select default configuration for outbreak investigation
+                                      </div>
+                                    </div>
+                                  </div>
+                                </uib-accordion-heading>
+                                <div ng-form="selectConfigForm" name="selectConfigForm">
+                                  <div id="selectConfig"
+                                    class="margin-top-negative-20 margin-top-md padding-left-0 padding-right-0 threat-hunt-connector-config-width">
+                                    <div>
+                                      <div><label class="font-075em">Select Configuration Target</label><span class="required text-danger">*</span></div>
+                                      <div
+                                        data-ng-class="{ 'has-error':threatHuntConfigForm.selectConfigForm.$invalid || threatHuntConfigForm.selectConfigForm.$pristine}"
+                                        class="cs-select width-275">
+                                        <select id="targetSelect" name="targetSelect" class="form-control input-sm logic-type font-size-11"
+                                          data-ng-disabled="disabled" data-ng-model="config.connectorType"
+                                          data-ng-options="key for key in connectorTypeList" data-ng-change="setConnectorType()" required>
+                                          <option value="" disabled>{{'APP.LABEL.SELECT_AN_OPTION' | translate}}</option>
+                                        </select>
+                                        <span class="fa fa-sort-desc"></span>
+                                      </div>
+                                      <div class="margin-top-lg"><label class="font-075em">Select Configuration</label><span
+                                          class="required text-danger">*</span></div>
+                                      <div class="display-flex">
+                                      <div
+                                        data-ng-class="{ 'has-error':threatHuntConfigForm.selectConfigForm.$invalid || threatHuntConfigForm.selectConfigForm.$pristine}"
+                                        class="cs-select width-275">
+                                        <select id="configurationSelect" name="configurationSelect"
+                                          class="form-control input-sm logic-type font-size-11" data-ng-disabled="disabled"
+                                          data-ng-model="config.selectedConfig"
+                                          data-ng-options="configuration as configuration.name for configuration in allConfigurations track by configuration.id"
+                                          data-ng-change="setConnectorConfiguration()" required>
+                                          <option value="" disabled>{{'APP.LABEL.SELECT_AN_OPTION' | translate}}</option>
+                                        </select>
+                                        <span class="fa fa-sort-desc"></span>
+                                      </div>
+                                      <!-- health check -->
+                                      <div class="content-detail-form" data-ng-show="config.selectedConfig">
+                                        <div class="content-detail-health margin-left-sm">
+                                          <span class="content-detail-health-check text-uppercase">
+                                            <i class="fa fa-stethoscope" aria-hidden="true"></i> {{'WZ_CONNECTOR.HEALTH_CHECK' |
+                                            translate}}:
+                                            <span>
+                                              <span data-ng-if="!healthCheckProcessing"
+                                                class="label-{{config.fazConnectorHealth.status | lowercase}}">
+                                                {{config.fazConnectorHealth.status}}
+                                              </span>
+                                            </span>
+                                          </span>
+                                          <a class="content-detail-refresh-icon" href="#" data-ng-click="checkFAZConnectoHealth()"
+                                            data-ng-class="{'pointer-event-none': healthCheckProcessing}">
+                                            <span class="fa icon icon-refresh" data-ng-class="{'fa-spin': healthCheckProcessing}"
+                                              title="{{'WZ_CONNECTOR.CHECK_HEALTH_STATUS' | translate}}"></span>
+                                          </a>
+                                          <span class="content-detail-info-icon" data-uib-tooltip="{{config.fazConnectorHealth.message}}"
+                                            tooltip-class="break-word" data-tooltip-append-to-body="true">
+                                            <i class="icon icon-information"></i>
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              
                               <div data-ng-if="huntTool.label!=='NIST National Vulnerability Database'"
                                 class="form-group">
                                 <div uib-accordion-group class="panel-default" id="accordion-params-config-{{ $index }}"
@@ -231,7 +306,7 @@
           id="solutionpack-configure-back-env-btn" data-ng-click="backSelectHuntTools()"><i
             class="fa fa-chevron-left margin-right-sm"></i>{{viewWidgetVars.THIRD_PAGE_BACK}}</button>
         <button type="button" class="btn btn-primary pull-right btn-sm margin-top-lg margin-right-lg"
-          data-ng-click="nextNotification(threatHuntConfigForm)" data-ng-disabled="isConnectorsHealthy"
+          data-ng-click="nextNotification(threatHuntConfigForm)" data-ng-disabled="isConnectorsHealthy || healthCheckProcessing"
           id="solutionpack-configure-env-next-btn">{{viewWidgetVars.THIRD_PAGE_NEXT}}<i class="fa margin-left-sm"
             data-ng-class="isConnectorsHealthy ? 'fa-spin fa-spinner' : 'fa-chevron-right'"></i>
         </button>

--- a/widget/view.html
+++ b/widget/view.html
@@ -199,7 +199,7 @@
                                               </span>
                                             </span>
                                           </span>
-                                          <a class="content-detail-refresh-icon" href="#" data-ng-click="checkFAZConnectoHealth()"
+                                          <a class="content-detail-refresh-icon" href="#" data-ng-click="checkFAZConnectorHealth()"
                                             data-ng-class="{'pointer-event-none': healthCheckProcessing}">
                                             <span class="fa icon icon-refresh" data-ng-class="{'fa-spin': healthCheckProcessing}"
                                               title="{{'WZ_CONNECTOR.CHECK_HEALTH_STATUS' | translate}}"></span>


### PR DESCRIPTION
default configuration setting added for FAZ connector 

Mantis -1173631
Select default configuration accordion added- 
This section will have list of Self or Agent Configuration list only for FAZ connector Tab.

On selecting the configuration - health check will be triggered and the next button will be disabled.
If health connector is not available and next button is clicked then toaster error will be thrown.
The next step will be executed only for the selected connector configuration whose health is available.


![updated text](https://github.com/user-attachments/assets/985e1a70-a34c-4bd8-a8b8-7ddd1f31ed2f)

![health check failed on next](https://github.com/user-attachments/assets/db0bad48-d3b0-4bcd-bccb-71b1fd64a750)




